### PR TITLE
Content updates

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -13,3 +13,7 @@ parts:
     title: Scholars 2023
   - file: info/mentors
     title: Mentors
+- caption: Research Outputs
+  chapters:
+  - file: output-guidelines/micropublications
+  - file: output-guidelines/seminar_presentations

--- a/info/scholars2023.md
+++ b/info/scholars2023.md
@@ -1,6 +1,6 @@
 # Impact Scholars 2023
 
-We are thrilled to introduce 15 teams of 74 Impact Scholars as part of our 2023 cohort! 
+We are thrilled to introduce 15 teams of 75 Impact Scholars as part of our 2023 cohort! 
 
 Their ambitious projects focus on pressing climate issues on local and global scales, as well as their societal impact.
 
@@ -19,7 +19,7 @@ A representation of the scholar projects' geographical regions of focus. The two
 
 Team "Brachiosaurus_Bharatanatyam_Leggiero"
 
-Pallaw Mishra, Shashank Kumar Roy, Wil Laura
+Pallaw Mishra, Shashank Kumar Roy , Wil Laura
 
 ---
 
@@ -149,7 +149,7 @@ Ninibeth Sarmiento Herrera, Elisa Passos, Lakhvinder Kaur
 
 Team "Beipiaosaurus moonwalk"
 
-Sofia Corradi, Daniela Velásquez, Magnolia Song, Maryann Alata Chambilla, Manojna Polisetty
+Sofia Corradi, Daniela Velásquez, Magnolia Song, Maryann Alata Chambilla, Manojna Polisett,  Andres Figueroa
 
 ---
 

--- a/info/scholars2023.md
+++ b/info/scholars2023.md
@@ -59,7 +59,7 @@ Douglas Medeiros Nehme, Gabriel Henrique da Silva Soares, Lívia Sancho
 
 Team "Fukuivenator Rhumba"
 
-Sthitapragya Ray, Andrea A. Cabrera, Diana Marcela Guzmán Lugo, Vanni Consumi, Daria Proklova, Anonymous Contributor[^1]
+Sthitapragya Ray, Andrea A. Cabrera, Diana Marcela Guzmán Lugo, Vanni Consumi, Daria Proklova, Elizaveta Baranova-Parfenova
 
 ---
 

--- a/info/scholars2023.md
+++ b/info/scholars2023.md
@@ -19,7 +19,7 @@ A representation of the scholar projects' geographical regions of focus. The two
 
 Team "Brachiosaurus_Bharatanatyam_Leggiero"
 
-Pallaw Mishra, Shashank Kumar Roy , Wil Laura
+Shashank Kumar Roy , Wil Laura, Anonymous Contributor[^1]
 
 ---
 
@@ -59,7 +59,7 @@ Douglas Medeiros Nehme, Gabriel Henrique da Silva Soares, Lívia Sancho
 
 Team "Fukuivenator Rhumba"
 
-Sthitapragya Ray, Andrea A. Cabrera, Diana Marcela Guzmán Lugo, Elizaveta Baranova-Parfenova, Vanni Consumi, Daria Proklova
+Sthitapragya Ray, Andrea A. Cabrera, Diana Marcela Guzmán Lugo, Vanni Consumi, Daria Proklova, Anonymous Contributor[^1]
 
 ---
 
@@ -109,7 +109,7 @@ Ximena Miranda, Sergei Nabatov, Abdus Samad, Jesús Pozo T., Alethia Kielbasa, B
 
 Team "Fortepiano"
 
-Zhixian Yang, René Gabriel Navarro Labastida, Selyn Rousse Acuña Cama, Tejaswini M. Pawase, Rosmery Lidez Condori Huanca, Naomi Nafisa Rahman
+Zhixian Yang, René Gabriel Navarro Labastida, Tejaswini M. Pawase, Rosmery Lidez Condori Huanca, Naomi Nafisa Rahman, Anonymous Contributor[^1]
 
 ---
 
@@ -119,7 +119,7 @@ Zhixian Yang, René Gabriel Navarro Labastida, Selyn Rousse Acuña Cama, Tejaswi
 
 Team "Andante"
 
-Lana Flanjak, Natalia Gabdrakhmanova, Timon Kunze, Farukcan Sağlam
+Lana Flanjak, Natalia Gabdrakhmanova, Farukcan Sağlam, Anonymous Contributor[^1]
 
 ---
 
@@ -162,3 +162,4 @@ Team "Jintasaurus Skip Energico"
 Agnessa Karapetian, Ana Carolina Temporao Marques Filipe, Kamil Vlcek, Sedem Buabassah, Hatice Busra Gokbunar, Xintong Huang
 
 
+[^1]: The identity of a team member has been hidden upon their request.

--- a/info/scholars2023.md
+++ b/info/scholars2023.md
@@ -109,7 +109,7 @@ Ximena Miranda, Sergei Nabatov, Abdus Samad, Jesús Pozo T., Alethia Kielbasa, B
 
 Team "Fortepiano"
 
-Zhixian Yang, René Gabriel Navarro Labastida, Tejaswini M. Pawase, Rosmery Lidez Condori Huanca, Naomi Nafisa Rahman, Anonymous Contributor[^1]
+Zhixian Yang, René Gabriel Navarro Labastida, Tejaswini M. Pawase, Rosmery Lidez Condori Huanca, Naomi Nafisa Rahman, Selyn Rousse Acuña Cama
 
 ---
 

--- a/info/scholars2023.md
+++ b/info/scholars2023.md
@@ -59,7 +59,7 @@ Douglas Medeiros Nehme, Gabriel Henrique da Silva Soares, Lívia Sancho
 
 Team "Fukuivenator Rhumba"
 
-Sthitapragya Ray, Danny McCulloch, Andrea A. Cabrera, Diana Marcela Guzmán Lugo, Elizaveta Baranova-Parfenova, Vanni Consumi, Daria Proklova
+Sthitapragya Ray, Andrea A. Cabrera, Diana Marcela Guzmán Lugo, Elizaveta Baranova-Parfenova, Vanni Consumi, Daria Proklova
 
 ---
 

--- a/info/structure.md
+++ b/info/structure.md
@@ -5,9 +5,9 @@ The Climatematch Impact Scholars program runs between **October 2023** and **Jan
 ## **What is involved**
 - 💻**Computing resources**. Thanks to our partnership with [2i2c](https://2i2c.org/), selected groups will be provided with continued access to the Climatematch JupyterHub until the end of the program with a possibility of further extension if the scholars and their mentor are interested in working towards a peer-reviewed publication. 
 
-- 📝 **Citable micropublication**. At the end of the program, the scholars will write up their results in a micropublication that will be publicized on the program website and assigned a DOI. The scholars will also be offered a chance to share their work in their native language to increase its impact in their community.
+- 📝 **Citable micropublication**. At the end of the program, the scholars will write up their results in a [micropublication](../output-guidelines/micropublications.md) that will be publicized on the program website and assigned a DOI. The scholars will also be offered a chance to share their work in their native language to increase its impact in their community.
 
-- 🗣️ **Seminar presentation**. Also at the end of the program, the scholars will give a 20-minute virtual seminar that will be advertised on Climatematch social media and recorded for subsequent sharing on the course website.
+- 🗣️ **Seminar presentation**. Also at the end of the program, the scholars will give a 20-minute [virtual seminar](../output-guidelines/seminar_presentations.md) that will be advertised on Climatematch social media and recorded for subsequent sharing on the course website.
 
 - 🦉 **Mentorship**. We endeavour to match every team to a suitable mentor who connects with the scholars synchronously or asynchronously at least once a month and provides feedback on their research outputs. 
 

--- a/info/structure.md
+++ b/info/structure.md
@@ -3,15 +3,15 @@
 The Climatematch Impact Scholars program runs between **October 2023** and **January 2024**.
 
 ## **What is involved**
-- **Computing resources**. Thanks to our partnership with [2i2c](https://2i2c.org/), selected groups will be provided with continued access to the Climatematch JupyterHub until the end of the program with a possibility of further extension if the scholars and their mentor are interested in working towards a peer-reviewed publication. 
+- 💻**Computing resources**. Thanks to our partnership with [2i2c](https://2i2c.org/), selected groups will be provided with continued access to the Climatematch JupyterHub until the end of the program with a possibility of further extension if the scholars and their mentor are interested in working towards a peer-reviewed publication. 
 
-- **Citable micropublication**. At the end of the program, the scholars will write up their results in a micropublication that will be publicized on the program website and assigned a DOI. The scholars will also be offered a chance to share their work in their native language to increase its impact in their community.
+- 📝 **Citable micropublication**. At the end of the program, the scholars will write up their results in a micropublication that will be publicized on the program website and assigned a DOI. The scholars will also be offered a chance to share their work in their native language to increase its impact in their community.
 
-- **Seminar presentation**. Also at the end of the program, the scholars will give a 20-minute virtual seminar that will be advertised on Climatematch social media and recorded for subsequent sharing on the course website.
+- 🗣️ **Seminar presentation**. Also at the end of the program, the scholars will give a 20-minute virtual seminar that will be advertised on Climatematch social media and recorded for subsequent sharing on the course website.
 
-- **Mentorship**. We endeavour to match every team to a suitable mentor who connects with the scholars synchronously or asynchronously at least once a month and provides feedback on their research outputs. 
+- 🦉 **Mentorship**. We endeavour to match every team to a suitable mentor who connects with the scholars synchronously or asynchronously at least once a month and provides feedback on their research outputs. 
 
-- **Community support**. There will be regular check-ins from the program organisers on the #cisp-community forum channel on the Climatematch's Discord Community Server for participants to share both successes and struggles.
+- 🧑‍🤝‍🧑**Community support**. There will be regular check-ins from the program organisers on the #cisp-community forum channel on the Climatematch's Discord Community Server for participants to share both successes and struggles.
 
 We are actively working to provide participants with further professional and academic opportunities and additionally encourage them to take part in Climatematch seminars, journal club meetings, and professional development survey series. These are not strictly part of the program, but are aligned with the scholars' project topics and career aspirations.
 
@@ -19,8 +19,20 @@ We are actively working to provide participants with further professional and ac
 ## **Program tentative timeline**
 <table style="width:90%">
 <tr>
+    <td><b>2 August 2023</b></td>
+    <td>Applications open</td>
+</tr>
+<tr>
+    <td><b>8 September 2023</b></td>
+    <td>Application deadline</td>
+</tr>
+<tr>
+    <td><b>3 October 2023</b></td>
+    <td>Application decisions</td>
+</tr>
+<tr>
     <td><b>9 October 2023</b></td>
-    <td>Impact Scholars survey deadline</td>
+    <td>Impact Scholars Entrance Survey deadline</td>
 </tr>
 <tr>
     <td><b>16-17 October 2023</b></td>
@@ -31,16 +43,24 @@ We are actively working to provide participants with further professional and ac
     <td>Regular check-ins on Discord and mentor meetings</td>
 </tr>
 <tr>
+    <td><b>December 2024</b></td>
+    <td>Workshop on micropublications (TBC)</td>
+</tr>
+<tr>
     <td><b>12th January 2024</b></td>
-    <td>Research output submission deadline</td>
+    <td>Micropublication submission deadline</td>
 </tr>
 <tr>
     <td><b>January 2024</b></td>
     <td>End-of-program Celebration Event</td>
 </tr>
 <tr>
+    <td><b>January 2024</b></td>
+    <td>Impact Scholars Exit Survey deadline</td>
+</tr>
+<tr>
     <td><b>February 2024</b></td>
-    <td>Feedback on research outputs</td>
+    <td>Feedback on micropublications</td>
 </tr>
 <tr>
     <td><b>March-April 2024</b></td>

--- a/output-guidelines/micropublications.md
+++ b/output-guidelines/micropublications.md
@@ -1,0 +1,7 @@
+# Micropublications
+
+```{admonition} Workshop
+We are working to arrange a workshop on micropublications in December 2023. Check back for confirmation! 
+```
+
+Detailed guidelines on the micropublication format will be shared in due course!

--- a/output-guidelines/seminar_presentations.md
+++ b/output-guidelines/seminar_presentations.md
@@ -1,0 +1,5 @@
+# Seminar presentations
+
+Seminar talks will take place in March/April 2024. 
+
+Guidelines and presentation schedule will be shared in due course!

--- a/workshops/oral_presentations.md
+++ b/workshops/oral_presentations.md
@@ -1,3 +1,0 @@
-# Oral presentations
-
-This workshop will take place in January 2024. Check back in due course!

--- a/workshops/science_writing.md
+++ b/workshops/science_writing.md
@@ -1,3 +1,0 @@
-# Science writing
-
-This workshop will take place in December 2023. Check back in due course!


### PR DESCRIPTION
- Added the missing scholar
- Removed the double-duty TA from their non-chosen team
- Added emojis to the "What's involved" section to make it a bit more lively
- Updated the timeline in line with yesterday's consensus
- **!!!** Also included a line for the "exit survey deadline", but I am not sure if we want to have it at the official "end of the programme" (Jan) or after the seminar (Mar/Apr)
- Added a "Research Outputs" section like @Nat-Stein suggested, but with no strong commitment to workshops. I think that these pages could contain micropub/presentation guidelines whether or not those can also be considered "workshop materials". Logistic info about the workshops could be placed in an admonition at the top of the page. This is what it looks like at the moment 👇 
![image](https://github.com/ClimateMatchAcademy/impact-scholars/assets/29711337/ec183096-5b36-4467-ab85-46ab3a9b9766)
