### PR TITLE
Add mentor guidelines

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -13,6 +13,8 @@ parts:
     title: Scholars 2023
   - file: info/mentors
     title: Mentors
+    sections:
+    - file: info/mentoring_guidelines
 - caption: Research Outputs
   chapters:
   - file: output-guidelines/micropublications

--- a/info/mentoring_guidelines.md
+++ b/info/mentoring_guidelines.md
@@ -1,0 +1,137 @@
+# Mentoring guidelines
+
+Mentoring is about helping each other expand and grow. It is a process in which an experienced person (mentor) guides, teaches, trains, supports, and encourages others (mentees) to achieve their personal goals and objectives in a limited time. Effective mentoring provides opportunities to share talents, skills, experiences, and knowledge gained through regular training, ongoing coaching, and feedback for both mentees and mentors.
+
+## Mentorship during the program
+
+The Climatematch Impact Scholars Program aspires to the [mentorship standards set by Harvard University][harvard] in which mentors and mentees both establish their goals and expectations and actively collaborate to maintain a mutually beneficial mentoring relationship.
+
+### Mentor matching (early October)
+
+Mentors are matched to project groups based on subject expertise, preference, and, where possible, timezone compatibility. Mentors and mentees receive a joint introductory email from the program organizers.
+
+It is expected that mentors and mentees are committed to investing <u>a minimum of 1-2 hours per month</u> to establish and sustain a successful mentoring relationship throughout the program.
+
+Mentors are additionally expected to sign the [Climatematch Volunteer Agreement](https://airtable.com/app32npl2ZlbJvtXK/shrrFrKgFi8VNDiAu).
+
+### First interactions (October)
+
+Mentorship can take place through synchronous meetings on a video conferencing platform and/or asynchronously via email or another, mutually agreed upon communication platform.
+
+We suggest that the first mentor-mentee interactions:
+- <u>discuss background, experiences, and interests of everyone involved</u>. This will give the mentees an opportunity to practice their networking skills and allow the mentor to tailor their mentoring approach to the mentees' needs.
+
+- <u>set clear expecations</u>. What do you wish to gain from the mentoring relationship? How often will you communicate? What communication channels will you use? When suggesting communication platforms, be mindful of potential accessibility restrictions elsewhere in the world.
+
+- <u>discuss the project proposal</u>. The proposal outlining the mentees' current results and the work proposed during the program is attached to the introductory email sent by the organizers. Bear in mind that scholars are working on their project part-time and are required to submit a [micropublication](../output-guidelines/micropublications.md) by **12th January 2024**. 
+
+- <u>work together to set specific, achievable goals for the next month</u>. These will help the mentees allocate responsibilities among themselves and will assist the mentor in their next interaction with the scholars. 
+
+### Progress updates (November, December)
+ Subsequent mentoring interactions should be geared towards helping the scholars make progress on their project in line with the previously set expectations. 
+
+This should involve, but need not be limited to, <u>guidance on analysis approaches, result interpretation and visualization, and the planning of next steps</u>. We suggest that the previously defined monthly goals are revisited and that new goals are set for the next period after progress evaluation. It is important to give the mentees an opportunity to share their successes and struggles alike. As part of this process, mentors are welcome to share learning and development resources to help their mentees achieve their collective and individual professional goals. 
+
+Planning these interactions will keep the mentoring partnership on track and focused on significant objectives. 
+
+In addition, we encourage mentors and mentees to regularly <u>assess the effectiveness of their collaboration</u> and to respectfully work to improve it. If either of the involved parties do not feel content with the partnership and is struggling to resolve the problems internally, please do not hesitate to reach out to the program organizers via email mentors@climatematch.io. 
+
+### End of program support (December, early January)
+Mentor-mentee interactions should be organized with the program end date in mind such that the mentorship focus gradually shifts from data analyses and interpretation to result presentation.
+
+It is also important to understand that the end of the program and formal mentorship need not mean the end of the professional relationship between the mentor and the scholars. Your final interactions during the program are an excellent opportunity to share your overall experience with the program, celebrate achievements, and, if there is mutual interest, discuss ways for the partnership to continue beyond the program. For example, if the mentor and the scholars are keen to continue their collaboration and develop the project into a journal publication or a conference presentation, we will try our best to facilitate the process and extend scholar access to computing resources.   
+
+### Micropublication review (12th January - 12th February 2024)   
+After scholars submit the final draft of their [micropublication](../output-guidelines/micropublications.md) (deadline: 12th January), the program organizers will forward it to the mentors who will have until **12th February** to provide written feedback on the piece.
+
+Considering that mentors will have guided the scholars through their analyses and result interpretation, it is expected that this feedback will focus primarily on the scholars' clarity of expression and result presentation without requesting additional analyses. Detailed review guidelines will be provided in due course!
+
+Scholars will then have time until the end of February to address the received feedback and submit a revised version for publication on the program website.
+
+---
+## Ethics of mentoring
+
+Mentors and mentees should be aware of the [Climatematch Code of Conduct][coc]. Mentors must continually examine and reflect on their ethical values ​​and how they can influence decisions in their mentoring practice. Mentors must take responsibility for the power they hold and never use it abusively over more vulnerable others. In Climatematch, we are committed to having an open and transparent reporting structure for any abuse of power. Please report any anomaly at mentors@climatematch.io. 
+
+---
+## Mentoring best practices
+
+### Mentors
+We ask that mentors strive to follow the best mentorship practices and actively work to hone the following qualities (source: [Manchester Metropolitan University][mmu]).
+
+1. **Self-awareness**: relates to having your own personal goals, career, and knowing your own strengths.
+
+2. **Organizational know-how**: means individual knowledge that mentors have and that provides an advantage over others in the same field. It is about knowing how things work.
+   
+3. **Credibility** in determining objectives and developing capabilities: it is important that mentors have personal and professional credibility in their area.
+   
+4. **Accessibility**: The success of mentoring depends on the time dedicated to the mentees. Additionally, mentors should talk regularly to establish a comfort level in the relationship around easy topics, then, when a challenge or concern arises, it is much easier to have a helpful discussion.
+   
+5. **Communication and active listening** (taking into account interests, body language, attention, and giving advice) help determine the motivations and needs of your mentees.
+   
+6. **Ability to empower**: Mentors have the ability to create a work environment in which mentees feel safe to contribute in different ways.
+   
+7. **A desire to help others train**: Mentors must understand how mentees gain experience from mentoring.
+   
+8. **Inventiveness**: Mentors must be open-minded to do new and different things in mentoring to help mentees gain broader perspectives from their experiences.
+   
+9. **Empathy**: the ability to sense the learners' emotions or what they might be thinking or feeling.
+   
+10. **Understanding**: Mentors can observe their mentees' learning and provide constructive feedback.
+   
+
+[The Actuaries Without Borders][awb] have done an excellent job summarizing specific dos and don'ts for mentors which we have adapted to our program:
+
+
+|       DO      |        DON'T        |
+|------------------|-----------------------|
+| 1. Do ask your mentee to have an agenda of questions or discussion topics prepared for your next interaction. | 1. Don't allow your mentee to have unrealistic expectations without explaining why they are unrealistic. |
+| 2. Do maintain a friendly tone and be positive. | 2. Don't take over the conversation; give your mentee ownership of the conversation as well. |
+| 3. Do be aware that your mentee has a different cultural background. | 3. Don't provide commercial services or advice that normally require fees. |
+| 4. Do encourage development opportunities for your mentee as opposed to focusing on immediate problem solving. | 4. Don't use words others might find offensive and avoid personal attacks or name-calling. |
+| 5. Do bring the focus back to relevant topics when the conversation veers away. | 5. Don't attempt to resolve your mentee's problems yourself instead of leading your mentee to find answers on their own. |
+| 6. Do share pertinent work practice experiences with your mentee. | 6. Don't attempt to solve or assist the mentee to solve personal or financial problems, especially those beyond actuarial nature. |
+| 7. Do give positive reinforcement when your mentee is doing something right. | 7. Don't allow the focus of the conversation to get away from you. |
+| 8. Do serve as a sounding board for ideas. | 8. Don't discuss confidential information and don't share private information. |
+| 9. Do set goals with your mentee. |  |
+
+
+```{note}
+
+ Immediately communicate any violation of our Code of Conduct to the program organizers via mentors@climatematch.io and let them handle the termination of the mentorship arrangement if necessary.
+
+```
+
+
+### Mentees
+Mentorship is a two-way relationship, so we ask all scholars to actively practice being a good mentee when interacting with their mentor. (source: [The Actuaries Without Borders][awb])
+  
+|       DO       |        DON'T         |
+|------------------|-----------------------|
+| 1. Do take responsibility for scheduling regular interactions with your mentor. | 1. Don't wait for your mentor to schedule your mentorship video conference. |
+| 2. Do acknowledge how busy your mentor is. | 2. Don't come unprepared to discuss your questions or topics. |
+| 3. Do be on time. | 3. Don't be too focused on immediate problem solving as opposed to development opportunities that will help you in the long run. |
+| 4. Do be prepared. | 4. Don't talk about inappropriate topics. |
+| 5. Do be honest. | 5. Don't use words others might find offensive and avoid personal attacks or name-calling. |
+| 6. Do be receptive to feedback. | 6. Don't be unreceptive to suggestions offered by your mentor. |
+| 7. Do be willing to tactfully and respectfully disagree with your mentor. | 7. Don't discuss confidential information and don't share private information. |
+| 8. Do follow through on commitments and goals set during the mentoring sessions. | 8. Don't be negative. |
+| 9. Do admit mistakes and take responsibility for them. | 9. Don't play the victim. |
+| 10. Do be aware that your mentor has a different cultural background. |  |
+| 11. Do have a goal or goals in mind. |  |
+| 12. Do stay focused on your goals. |  |
+| 13. Do discuss whether your mentor's suggestions were helpful and what positive effects they have had on your career. |  |
+| 14. Do thank your mentor. |  |
+
+
+```{note}
+
+ Immediately communicate any violation of our Code of Conduct to cisp organizers via mentors@climatematch.io and let them handle the termination of the mentorship arrangement if necessary.
+
+```
+<!-- Links -->
+[harvard]: https://hlc.harvard.edu/wp-content/uploads/sites/2412/2015/10/Mentoring_Guide.pdf
+[mmu]: https://www.mmu.ac.uk/careers/students/mentor-me
+[coc]: https://github.com/NeuromatchAcademy/precourse/blob/main/CODE_OF_CONDUCT.md
+[awb]: https://www.actuaries.org/AWB/Projects/Global_Mentorship/Guidelines%20for%20Mentors%20and%20Mentees.pdf
+[osl]: https://opensciencelabs.org/guidelines/mentoring/guide/

--- a/info/mentoring_guidelines.md
+++ b/info/mentoring_guidelines.md
@@ -51,7 +51,7 @@ Scholars will then have time until the end of February to address the received f
 ---
 ## Ethics of mentoring
 
-Mentors and mentees should be aware of the [Climatematch Code of Conduct][coc]. Mentors must continually examine and reflect on their ethical values ​​and how they can influence decisions in their mentoring practice. Mentors must take responsibility for the power they hold and never use it abusively over more vulnerable others. In Climatematch, we are committed to having an open and transparent reporting structure for any abuse of power. Please report any anomaly at mentors@climatematch.io. 
+Mentors and mentees should be aware of the [Climatematch Code of Conduct][coc]. Mentors must continually examine and reflect on their ethical values ​​and how they can influence decisions in their mentoring practice. Mentors must take responsibility for the power they hold and never use it abusively over more vulnerable others. In Climatematch, we are committed to having an open and transparent reporting structure for any abuse of power. Please report any anomaly at mentors@climatematch.io and report any violations of the Code of Conduct through this [reporting form](https://airtable.com/app3DAkSp0lV5kU38/shrezDSthWPlJ4Rpy). 
 
 ---
 ## Mentoring best practices

--- a/info/mentoring_guidelines.md
+++ b/info/mentoring_guidelines.md
@@ -129,6 +129,20 @@ Mentorship is a two-way relationship, so we ask all scholars to actively practic
  Immediately communicate any violation of our Code of Conduct to cisp organizers via mentors@climatematch.io and let them handle the termination of the mentorship arrangement if necessary.
 
 ```
+
+## Acknowledgement
+
+Substantial portions of this document were adapted from:
+* [Open Science Lab Mentoring Guide][osl]
+* [Harvard Mentoring Guide][harvard]
+* [Mentor Me Programme of the Manchester Metropolitan University][mmu]
+* [Guidelines for Mentors and Mentees from the AWB][awb]
+
+## License
+
+This document incorporates and adapts content from [Open Science Lab Mentoring Guide][osl], which is licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). To the extent that this document includes content from the original source, it is also licensed under CC BY 4.0.
+
+
 <!-- Links -->
 [harvard]: https://hlc.harvard.edu/wp-content/uploads/sites/2412/2015/10/Mentoring_Guide.pdf
 [mmu]: https://www.mmu.ac.uk/careers/students/mentor-me

--- a/info/scholars2023.md
+++ b/info/scholars2023.md
@@ -119,7 +119,7 @@ Zhixian Yang, René Gabriel Navarro Labastida, Tejaswini M. Pawase, Rosmery Lide
 
 Team "Andante"
 
-Lana Flanjak, Natalia Gabdrakhmanova, Farukcan Sağlam, Anonymous Contributor[^1]
+Lana Flanjak, Natalia Gabdrakhmanova, Farukcan Sağlam, Timon Kunze
 
 ---
 


### PR DESCRIPTION
Built on the [guidelines](https://github.com/MGomezN/mentoring_guidelines/blob/main/Mentoring%20Guidelines.md) compiled by @MGomezN 💪 

My edits:
- reorganised the Harvard content, which was describing mentor-mentee interactions ~chronologically, into the CISP-specific guidelines as I had envisioned those as timeline-like too
   - set a 12th Feb deadline for mentor feedback (just because it's a full month) <- **NB** this has not been discussed!
   - description of micropub review process might need to be revised in line with the ongoing slack discussion 
- moved the "Skills and experience required to be a mentor" section under "best practices" since we are not using most of those skills for mentor selection and are treating them as aspirational instead
- replaced all instances of "CISP" by the full program name, fixed the email address