### PR TITLE
Add mentor info

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ sphinx:
     language: en
     myst_heading_anchors: 2
     html_theme_options:
-      announcement: "<font size = '6'>🌍🌎🌏 We are looking for mentors with experience in climate research! <br> <a href='https://airtable.com/appLHqbcnAQ1EUO47/shrDDmUFZ594k6KQ0' style='color:#f0ba7d;'><b>APPLY HERE!</b></a></font>"  
+      # announcement: "<font size = '6'>🌍🌎🌏 We are looking for mentors with experience in climate research! <br> <a href='https://airtable.com/appLHqbcnAQ1EUO47/shrDDmUFZ594k6KQ0' style='color:#f0ba7d;'><b>APPLY HERE!</b></a></font>"  
       logo:
         text: Climatematch Impact Scholars Program 
     html_sidebars:

--- a/impact-scholars/mentors.md
+++ b/impact-scholars/mentors.md
@@ -1,9 +1,36 @@
 # Mentors
 Mentors are **experienced scientists interested in supporting a group throughout the development of their research project** between October 2023 and January 2024.
 
-```{admonition} Mentor applications are open!
+```{admonition} One last spot remaining!
 Apply here: https://airtable.com/appLHqbcnAQ1EUO47/shrDDmUFZ594k6KQ0
 ```
+---
+## Mentors 2023
+- **Gizachew Agegn**
+  - [*Projected Influences of Interannual Climate Variability on Summer Monsoon Onset and Extreme Weather Events in the Indonesia-North Australia Monsoon Region*](./scholars2023.md#projected-influences-of-interannual-climate-variability-on-summer-monsoon-onset-and-extreme-weather-events-in-the-indonesia-north-australia-monsoon-region)
+- **Emma Daniels**
+  - [*ENSO's Influence on the Coastal Upwelling along Northwest Africa through the Pacific-North Atlantic Teleconnection*](./scholars2023.md#ensos-influence-on-the-coastal-upwelling-along-northwest-africa-through-the-pacific-north-atlantic-teleconnection)
+- **Surajit Deb Barma**
+  - [*Impact of Deforestation and Multi-year Cyclical Processes on Precipitation Patterns and Cereal Production in Congo River Basin*](./scholars2023.md#impact-of-deforestation-and-multi-year-cyclical-processes-on-precipitation-patterns-and-cereal-production-in-congo-river-basin)
+  - [*Predicting future impacts of ENSO on NDVI in the Greater Horn of Africa*](./scholars2023.md#predicting-future-impacts-of-enso-on-ndvi-in-the-greater-horn-of-africa)
+- **Brittany Engle**
+  - [*Fire Risk Assessment of the Andean-Patagonian Forest*](./scholars2023.md#fire-risk-assessment-of-the-andean-patagonian-forest)
+  - [*Wildfires in Angola: Burn Areas and Vegetation Index*](./scholars2023.md#wildfires-in-angola-burn-areas-and-vegetation-index)
+- **Fabrizio Falasca**
+  - [*Comparing Sea Level Height Measurements from Tidal Gauges and ECCO Model in Extreme Weather Events*](./scholars2023.md#comparing-sea-level-height-measurements-from-tidal-gauges-and-ecco-model-in-extreme-weather-events)
+  - [*Deepening into the rainy impact of El Niño events over South of Brazil precipitation*](./scholars2023.md#deepening-into-the-rainy-impact-of-el-niño-events-over-south-of-brazil-precipitation)
+- **Muhammed Muhshif Karadan**
+  - [*Proposal for heatwave in Asia(India)*](./scholars2023.md#proposal-for-heatwave-in-asiaindia)
+  - [*Understanding historical and future impacts of El Niño on climate and food production in Colombia and Indonesia*](./scholars2023.md#understanding-historical-and-future-impacts-of-el-niño-on-climate-and-food-production-in-colombia-and-indonesia)
+- **Oz Kira**
+  - [*Understanding the interactions of socio-economic policy, land use change, climate and carbon sequestration within the biomes of Mato Grosso: Integrating Land Cover, Precipitation, Temperature, GPP and Economic Factors*](./scholars2023.md#understanding-the-interactions-of-socio-economic-policy-land-use-change-climate-and-carbon-sequestration-within-the-biomes-of-mato-grosso-integrating-land-cover-precipitation-temperature-gpp-and-economic-factors)
+- **Kenny T.C. Lim Kam Sian**
+  - [*The Past and Future of Mediterranean Heat Waves*](./scholars2023.md#the-past-and-future-of-mediterranean-heat-waves)
+- **Risa Madoff**
+  - [*Assessing Spatio-Temporal Precipitation Variability and Extreme Events in India*](./scholars2023.md#assessing-spatio-temporal-precipitation-variability-and-extreme-events-in-india)
+- **Tejas Dattaram More**
+  - [*Understand underlying mechanisms of ENSO and predicting its impact on the countries surrounding the Niño Region*](./scholars2023.md#understand-underlying-mechanisms-of-enso-and-predicting-its-impact-on-the-countries-surrounding-the-niño-region)
+
 
 ---
 ## Why be a mentor? 

--- a/impact-scholars/mentors.md
+++ b/impact-scholars/mentors.md
@@ -1,8 +1,8 @@
 # Mentors
 Mentors are **experienced scientists interested in supporting a group throughout the development of their research project** between October 2023 and January 2024.
 
-```{admonition} One last spot remaining!
-Apply here: https://airtable.com/appLHqbcnAQ1EUO47/shrDDmUFZ594k6KQ0
+```{important}
+  Applications for the 2023 program have closed!
 ```
 ---
 ## Mentors 2023

--- a/impact-scholars/mentors.md
+++ b/impact-scholars/mentors.md
@@ -26,6 +26,8 @@ Apply here: https://airtable.com/appLHqbcnAQ1EUO47/shrDDmUFZ594k6KQ0
   - [*Understanding the interactions of socio-economic policy, land use change, climate and carbon sequestration within the biomes of Mato Grosso: Integrating Land Cover, Precipitation, Temperature, GPP and Economic Factors*](./scholars2023.md#understanding-the-interactions-of-socio-economic-policy-land-use-change-climate-and-carbon-sequestration-within-the-biomes-of-mato-grosso-integrating-land-cover-precipitation-temperature-gpp-and-economic-factors)
 - **Kenny T.C. Lim Kam Sian**
   - [*The Past and Future of Mediterranean Heat Waves*](./scholars2023.md#the-past-and-future-of-mediterranean-heat-waves)
+- **Luz de Lourdes Aurora**
+  - [*Analyzing Global Wind Potential for the Next 50 Years and its socio-economic impact*](./scholars2023.md#analyzing-global-wind-potential-for-the-next-50-years-and-its-socio-economic-impact)
 - **Risa Madoff**
   - [*Assessing Spatio-Temporal Precipitation Variability and Extreme Events in India*](./scholars2023.md#assessing-spatio-temporal-precipitation-variability-and-extreme-events-in-india)
 - **Tejas Dattaram More**

--- a/impact-scholars/scholars2023.md
+++ b/impact-scholars/scholars2023.md
@@ -1,6 +1,6 @@
 # Impact Scholars 2023
 
-We are thrilled to introduce 15 teams of 75 Impact Scholars as part of our 2023 cohort! 
+We are thrilled to introduce **15 teams** of **75 Impact Scholars** representing **30 countries** as part of our 2023 cohort! 
 
 Their ambitious projects focus on pressing climate issues on local and global scales, as well as their societal impact.
 
@@ -15,7 +15,7 @@ A representation of the scholar projects' geographical regions of focus. The two
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #a2bbd4; margin: 10px 0px;">1.</div></div>
 
-**Analyzing Global Wind Potential for the Next 50 Years and its socio-economic impact**
+## Analyzing Global Wind Potential for the Next 50 Years and its socio-economic impact
 
 Team "Brachiosaurus_Bharatanatyam_Leggiero"
 
@@ -25,141 +25,170 @@ Shashank Kumar Roy , Wil Laura, Anonymous Contributor[^1]
 
 <div style="text-align: center; line-height: 30px; color: white; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #313f76; margin: 10px 0px;">2.</div></div>
 
-**Comparing Sea Level Height Measurements from Tidal Gauges and ECCO Model in Extreme Weather Events**
+## Comparing Sea Level Height Measurements from Tidal Gauges and ECCO Model in Extreme Weather Events
 
 Team "Rajasaurus Baris"
 
 Franck Porteous, Faith Hunja, Hannah Krohn, C. Gabriela Mayorga-Adame, Ayman Said
 
+**Mentor:** Fabrizio Falasca
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #a2bbd4; margin: 10px 0px;">3.</div></div>
 
-**Assessing Spatio-Temporal Precipitation Variability and Extreme Events in India**
+## Assessing Spatio-Temporal Precipitation Variability and Extreme Events in India
 
 Team "Monsoon Blues"
 
 Stefy Thomas, Sattiki Ganguly, Jeciliya Selva Kiruba S, Khushi Dani, Dr. P P Choudhari, Sintayehu Fetene Demessie
 
+**Mentor:** Risa Madoff
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #67ada9; margin: 10px 0px;">4.</div></div>
 
-**Deepening into the rainy impact of El Niño events over South of Brazil precipitation**
+## Deepening into the rainy impact of El Niño events over South of Brazil precipitation
 
 Team "Staccato"
 
 Douglas Medeiros Nehme, Gabriel Henrique da Silva Soares, Lívia Sancho
 
+**Mentor:** Fabrizio Falasca
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #67ada9; margin: 10px 0px;">5.</div></div>
 
-**ENSO's Influence on the Coastal Upwelling along Northwest Africa through the Pacific-North Atlantic Teleconnection**
+## ENSO's Influence on the Coastal Upwelling along Northwest Africa through the Pacific-North Atlantic Teleconnection
 
 Team "Fukuivenator Rhumba"
 
 Sthitapragya Ray, Andrea A. Cabrera, Diana Marcela Guzmán Lugo, Vanni Consumi, Daria Proklova, Elizaveta Baranova-Parfenova
 
+**Mentor:** Emma Daniels
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #67ada9; margin: 10px 0px;">6.</div></div>
 
-**Fire Risk Assessment of the Andean-Patagonian Forest**
+## Fire Risk Assessment of the Andean-Patagonian Forest
 
 Team "Tyrannosaurus Tango Dolce"
 
 Cristian Farfan, Ricardo Rengifo, Raphael Rocha, Luciana Rojas, Franco Barrionuevo
 
+**Mentor:** Brittany Engle
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #f0ba7d; margin: 10px 0px;">7.</div></div>
 
-**Proposal for heatwave in Asia(India)**
+## Proposal for heatwave in Asia(India)
 
 Team "Tarantino"
 
 Ahmad Rashiq, Seyed Mehdi Mirbazel, Arihant Jain
 
+**Mentor:** Muhammed Muhshif Karadan
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #a2bbd4; margin: 10px 0px;">8.</div></div>
 
-**Impact of Deforestation and Multi-year Cyclical Processes on Precipitation Patterns and Cereal Production in Congo River Basin**
+## Impact of Deforestation and Multi-year Cyclical Processes on Precipitation Patterns and Cereal Production in Congo River Basin
 
 Team "Fortepiano, Hesperosaurus_bon"
 
 James Hartzell, Magda Altman, Pratik Bhandari, Lorenzo Pierini, Masoumeh Bahri, Rajiv Kumar Srivastava, Jeffrey N.A. Ayree
 
+**Mentor:** Surajit Deb Barma
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #67ada9; margin: 10px 0px;">9.</div></div>
 
-**Predicting future impacts of ENSO on NDVI in the Greater Horn of Africa**
+## Predicting future impacts of ENSO on NDVI in the Greater Horn of Africa
 
 Team "Saurophaganax_Popping_forte"
 
 Ximena Miranda, Sergei Nabatov, Abdus Samad, Jesús Pozo T., Alethia Kielbasa, Benedetta Francesconi
 
+**Mentor:** Surajit Deb Barma
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #67ada9; margin: 10px 0px;">10.</div></div>
 
-**Projected Influences of Interannual Climate Variability on Summer Monsoon Onset and Extreme Weather Events in the Indonesia-North Australia Monsoon Region**
+## Projected Influences of Interannual Climate Variability on Summer Monsoon Onset and Extreme Weather Events in the Indonesia-North Australia Monsoon Region
 
 Team "Fortepiano"
 
 Zhixian Yang, René Gabriel Navarro Labastida, Tejaswini M. Pawase, Rosmery Lidez Condori Huanca, Naomi Nafisa Rahman, Selyn Rousse Acuña Cama
 
+**Mentor:** Gizachew Agegn
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #f0ba7d; margin: 10px 0px;">11.</div></div>
 
-**The Past and Future of Mediterranean Heat Waves**
+## The Past and Future of Mediterranean Heat Waves
 
 Team "Andante"
 
 Lana Flanjak, Natalia Gabdrakhmanova, Farukcan Sağlam, Timon Kunze
 
+**Mentor:** Kenny T.C. Lim Kam Sian
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #67ada9; margin: 10px 0px;">12.</div></div>
 
-**Understand underlying mechanisms of ENSO and predicting its impact on the countries surrounding the Niño Region.**
+## Understand underlying mechanisms of ENSO and predicting its impact on the countries surrounding the Niño Region
 
 Team "Iguanacolossus_bogel Agitato"
 
 Kirtana Sunil Phatnani, Kimia Marvi, Anjana Shree, Neil Marc Sordilla, Eligio Maure, Danny McCulloch
 
+**Mentor:** Tejas Dattaram More
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #67ada9; margin: 10px 0px;">13.</div></div>
 
-**Understanding historical and future impacts of El Niño on climate and food production in Colombia and Indonesia**
+## Understanding historical and future impacts of El Niño on climate and food production in Colombia and Indonesia
 
 Team "Protoceratops_Jitterbug_Vivace"
 
 Ninibeth Sarmiento Herrera, Elisa Passos, Lakhvinder Kaur
 
+**Mentor:** Muhammed Muhshif Karadan
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: white; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #596a63; margin: 10px 0px;">14.</div></div>
 
-**Understanding the interactions of socio-economic policy, land use change, climate and carbon sequestration within the biomes of Mato Grosso: Integrating Land Cover, Precipitation, Temperature, GPP and Economic Factors**
+## Understanding the interactions of socio-economic policy, land use change, climate and carbon sequestration within the biomes of Mato Grosso: Integrating Land Cover, Precipitation, Temperature, GPP and Economic Factors
 
 Team "Beipiaosaurus moonwalk"
 
 Sofia Corradi, Daniela Velásquez, Magnolia Song, Maryann Alata Chambilla, Manojna Polisett,  Andres Figueroa
 
+**Mentor:** Oz Kira
+
 ---
 
 <div style="text-align: center; line-height: 30px; color: black; font-size: 18px; font-weight: bold; width: 30px;"><div style="background-color: #e18256; margin: 10px 0px;">15.</div></div>
 
-**Wildfires in Angola: Burn Areas and Vegetation Index**
+## Wildfires in Angola: Burn Areas and Vegetation Index
 
 Team "Jintasaurus Skip Energico"
 
 Agnessa Karapetian, Ana Carolina Temporao Marques Filipe, Kamil Vlcek, Sedem Buabassah, Hatice Busra Gokbunar, Xintong Huang
+
+**Mentor:** Brittany Engle
+
 
 
 [^1]: The identity of a team member has been hidden upon their request.

--- a/impact-scholars/scholars2023.md
+++ b/impact-scholars/scholars2023.md
@@ -1,6 +1,6 @@
 # Impact Scholars 2023
 
-We are thrilled to introduce **15 teams** of **75 Impact Scholars** representing **30 countries** as part of our 2023 cohort! 
+We are thrilled to introduce **15 teams** of **74 Impact Scholars** representing **30 countries** as part of our 2023 cohort! 
 
 Their ambitious projects focus on pressing climate issues on local and global scales, as well as their societal impact.
 
@@ -20,6 +20,8 @@ A representation of the scholar projects' geographical regions of focus. The two
 Team "Brachiosaurus_Bharatanatyam_Leggiero"
 
 Shashank Kumar Roy , Wil Laura, Anonymous Contributor[^1]
+
+**Mentor:** Luz de Lourdes Aurora
 
 ---
 
@@ -53,7 +55,7 @@ Stefy Thomas, Sattiki Ganguly, Jeciliya Selva Kiruba S, Khushi Dani, Dr. P P Cho
 
 Team "Staccato"
 
-Douglas Medeiros Nehme, Gabriel Henrique da Silva Soares, Lívia Sancho
+Douglas Medeiros Nehme, Lívia Sancho
 
 **Mentor:** Fabrizio Falasca
 


### PR DESCRIPTION
Added:
- mentor names to the `Scholars 2023` page
- a list of mentors and the projects they advise on to the `Mentors` page
- the number of countries our scholars represent

Update 2023/10/18 
Added the final mentor and removed the scholar who has dropped out

Update 2023/10/19 
Removed the banner and changed the admonition on `Mentors` page to say "applications closed"