### PR TITLE
Update programme timeline

### DIFF
--- a/impact-scholars/structure.md
+++ b/impact-scholars/structure.md
@@ -43,27 +43,23 @@ We are actively working to provide participants with further professional and ac
     <td>Regular check-ins on Discord and mentor meetings</td>
 </tr>
 <tr>
-    <td><b>December 2024</b></td>
-    <td>Workshop on micropublications (TBC)</td>
+    <td><b>18-20 December 2024</b></td>
+    <td>Workshop on micropublications</td>
 </tr>
 <tr>
     <td><b>12th January 2024</b></td>
     <td>Micropublication submission deadline</td>
 </tr>
 <tr>
-    <td><b>January 2024</b></td>
-    <td>End-of-program Celebration Event</td>
-</tr>
-<tr>
-    <td><b>January 2024</b></td>
-    <td>Impact Scholars Exit Survey deadline</td>
-</tr>
-<tr>
     <td><b>February 2024</b></td>
     <td>Feedback on micropublications</td>
 </tr>
 <tr>
+    <td><b>26-27 March 2024</b></td>
+    <td>Seminar presentations</td>
+</tr>
+<tr>
     <td><b>March-April 2024</b></td>
-    <td>Micropublication release and seminar presentations</td>
+    <td>Micropublication release</td>
 </tr>
 </table>

--- a/impact-scholars/structure.md
+++ b/impact-scholars/structure.md
@@ -47,7 +47,7 @@ We are actively working to provide participants with further professional and ac
     <td>Workshop on micropublications</td>
 </tr>
 <tr>
-    <td><b>12th January 2024</b></td>
+    <td><b>12 January 2024</b></td>
     <td>Micropublication submission deadline</td>
 </tr>
 <tr>


### PR DESCRIPTION
Updated the "program structure" page:
- added micropub workshop dates
- added seminar dates
- removed the celebratory closing event
- (for now) removed the exit survey deadline because doing the survey in January seems a tad early given our plans for Feb-Mar; will raise this on slack