### PR TITLE
Fix image path

### DIFF
--- a/scholar-outputs/2023/project14.md
+++ b/scholar-outputs/2023/project14.md
@@ -6,7 +6,7 @@ Team "Jintasaurus Skip Energico"
 
 Mentor: **Brittany Engle**
 
-```{figure} project14_summary.PNG
+```{figure} project14_summary.png
 ---
 width: 100%
 ---


### PR DESCRIPTION
Path to the graphical abstract of the "Wildfires in Angola.." project breaks after deployment due to a `.PNG` file extension that gets converted to `.png` in the `_build` folder. 
Changed the path to `.png`.